### PR TITLE
feat: documented deposits endpoint

### DIFF
--- a/bookings/components/deposit-list-response.yaml
+++ b/bookings/components/deposit-list-response.yaml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  deposits:
+    type: array
+    items:
+      $ref: 'view-deposit.yaml#'

--- a/bookings/components/view-booking.yaml
+++ b/bookings/components/view-booking.yaml
@@ -181,6 +181,11 @@ properties:
         type: string
         description: The post code of the company
         example: 'N1 5DL'
+  deposits:
+    type: array
+    description: An array of any deposits or payments made or requested against this booking.
+    items:
+      $ref: view-deposit.yaml
   lost:
     type: boolean
     description: Whether the booking has been lost

--- a/bookings/components/view-booking.yaml
+++ b/bookings/components/view-booking.yaml
@@ -186,6 +186,11 @@ properties:
     description: An array of any deposits or payments made or requested against this booking.
     items:
       $ref: view-deposit.yaml
+  refunds:
+    type: array
+    description: An array of any refunds made against this booking.
+    items:
+      $ref: view-refund.yaml
   lost:
     type: boolean
     description: Whether the booking has been lost

--- a/bookings/components/view-deposit.yaml
+++ b/bookings/components/view-deposit.yaml
@@ -50,3 +50,10 @@ properties:
     example: 2019-01-01 13:30:00
     type: string
     format: date-time
+  refund_ids:
+    name: refund_ids
+    description: An array of refund IDs relating to this deposit. These IDs relate to the `refunds` array within a booking.
+    type: array
+    items:
+      type: string
+      example: 5ca1de0628e7ff2356267753

--- a/bookings/components/view-deposit.yaml
+++ b/bookings/components/view-deposit.yaml
@@ -1,0 +1,54 @@
+type: object
+properties:
+  id:
+    name: id
+    description: The ID of the deposit.
+    example: 5ca1de0628e7ff2356267752
+    schema:
+      type: string
+  currency:
+    name: currency
+    description: The currency which this payment is in.
+    example: GBP
+    schema:
+      type: string
+  amount:
+    name: amount
+    description: The amount the deposit is for in pence.
+    example: 1000
+    schema:
+      type: integer
+  paid_type:
+    name: paid_type
+    description: Describes how the deposit was paid for.
+    example: Soda voucher
+    schema:
+      type: string
+  status:
+    name: status
+    description: The status which the deposit is in.
+    example: paid
+    schema:
+      type: string
+      enum:
+        - pending
+        - paid
+  type:
+    name: type
+    description: The type of deposit.
+    example: manual_payment
+    schema:
+      type: string
+      enum:
+        - request_auth
+        - manual_auth
+        - request_payment
+        - manual_payment
+        - customer_preorder
+  notes:
+    name: notes
+    description: Any notes that are attached to this deposit.
+    example: Customer called up over the phone to make this payment
+    schema:
+      type: string
+    nullable: true

--- a/bookings/components/view-deposit.yaml
+++ b/bookings/components/view-deposit.yaml
@@ -4,51 +4,49 @@ properties:
     name: id
     description: The ID of the deposit.
     example: 5ca1de0628e7ff2356267752
-    schema:
-      type: string
-  currency:
-    name: currency
-    description: The currency which this payment is in.
-    example: GBP
-    schema:
-      type: string
+    type: string
   amount:
-    name: amount
-    description: The amount the deposit is for in pence.
-    example: 1000
-    schema:
-      type: integer
+    $ref: /shared/money-response.yaml
   paid_type:
     name: paid_type
     description: Describes how the deposit was paid for.
     example: Soda voucher
-    schema:
-      type: string
+    type: string
+    nullable: true
   status:
     name: status
     description: The status which the deposit is in.
     example: paid
-    schema:
-      type: string
-      enum:
-        - pending
-        - paid
+    type: string
+    enum:
+      - pending
+      - paid
   type:
     name: type
     description: The type of deposit.
     example: manual_payment
-    schema:
-      type: string
-      enum:
-        - request_auth
-        - manual_auth
-        - request_payment
-        - manual_payment
-        - customer_preorder
+    type: string
+    enum:
+      - request_auth
+      - manual_auth
+      - request_payment
+      - manual_payment
+      - customer_preorder
   notes:
     name: notes
     description: Any notes that are attached to this deposit.
     example: Customer called up over the phone to make this payment
-    schema:
-      type: string
+    type: string
     nullable: true
+  payment_ref:
+    name: payment_ref
+    description: The Stripe payment reference for this deposit.
+    example: ch_1DTmw4DK5dphsmtEbSLGj6Wt
+    type: string
+    nullable: true
+  date:
+    name: date
+    description: The date when the deposit was created.
+    example: 2019-01-01 13:30:00
+    type: string
+    format: date-time

--- a/bookings/components/view-refund.yaml
+++ b/bookings/components/view-refund.yaml
@@ -1,0 +1,21 @@
+type: object
+properties:
+  id:
+    name: id
+    description: The ID of the refund.
+    example: 5ca1de0628e7ff2356267752
+    type: string
+  amount:
+    $ref: /shared/money-response.yaml
+  notes:
+    name: notes
+    description: Any notes that are attached to this refund.
+    example: A guest dropped out so we've refunded them 10%.
+    type: string
+    nullable: true
+  created_date:
+    name: created_date
+    description: The date when the deposit was created.
+    example: 2019-01-01 13:30:00
+    type: string
+    format: date-time

--- a/bookings/deposits.yaml
+++ b/bookings/deposits.yaml
@@ -1,0 +1,24 @@
+DepositsWithoutEntityId:
+  get:
+    summary: Get deposits
+    tags:
+      - Bookings
+    description: >-
+      Returns an array of all payments, deposits, authentications and refunds 
+      associated with this booking.
+    operationId: GetAllDeposits
+    responses:
+      200:
+        description: Deposits were successfully retrieved.
+        content:
+          application/json:
+            schema:
+              $ref: '/bookings/components/deposit-list-response.yaml'
+      401:
+        $ref: '/shared/standard-responses.yaml#/401'
+      403:
+        $ref: '/shared/standard-responses.yaml#/403'
+      404:
+        $ref: '/shared/standard-responses.yaml#/404'
+      429:
+        $ref: '/shared/standard-responses.yaml#/429'

--- a/main.yaml
+++ b/main.yaml
@@ -62,6 +62,8 @@ paths:
     $ref: /bookings/bookings.yaml#/BookingsWithoutEntityId
   /bookings/{bookingId}:
     $ref: /bookings/bookings.yaml#/BookingsWithEntityId
+  /bookings/{bookingId}/deposits:
+    $ref: /bookings/deposits.yaml#/DepositsWithoutEntityId
   /customers:
     $ref: /customers/customers.yaml#/CustomersWithoutEntityId
   /customers/{customerId}:

--- a/main.yaml
+++ b/main.yaml
@@ -61,8 +61,6 @@ paths:
     $ref: /bookings/bookings.yaml#/BookingsWithoutEntityId
   /bookings/{bookingId}:
     $ref: /bookings/bookings.yaml#/BookingsWithEntityId
-  /bookings/{bookingId}/deposits:
-    $ref: /bookings/deposits.yaml#/DepositsWithoutEntityId
   /customers:
     $ref: /customers/customers.yaml#/CustomersWithoutEntityId
   /customers/{customerId}:

--- a/shared/money-response.yaml
+++ b/shared/money-response.yaml
@@ -1,0 +1,12 @@
+type: object
+properties:
+  currency:
+    name: currency
+    description: The currency which this is in, in ISO-4217 format.
+    example: GBP
+    type: string
+  amount:
+    name: amount
+    description: The amount in pence.
+    example: 1000
+    type: string


### PR DESCRIPTION
Documented the `/booking/{bookingId}/deposits` endpoint, but I have a few things to discuss:

* I'm not too keen on the term `deposits`. We're storing payments, deposits and auths in here. Do you think "payments" is clearer? Or can you think of anything better?

* How do you reckon we should output currency values - as a float or an integer of pence?

* What about if we always output any kind of monetary value as a PHP money object, which keeps the currency and amount together?:

```json
"value": {
    "currency": "GBP",
    "amount": 1000
}
```

* Have I got the description for `paid_type` correct? Is there a better name we could use for that field?

* Is it weird behaviour that you can filter on deposits from the /bookings endpoint, but you have to go to the /bookings/{bookingId}/deposits endpoint to see those deposits?