### PR TITLE
docs: update documentation port and docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ $ cd collins-api-docs
 You can use Docker to host a local development environment of the documentation.
 
 ```shell
-$ docker-compose up
+$ docker-compose up -d
 ```
 
-The documentation will be served on localhost at port 8080 - http://localhost:8080
+The documentation will be served on localhost at port 5050 - http://localhost:5050
 
 ## Publishing
 


### PR DESCRIPTION
The [docker-compose.yml](https://github.com/designmynight/collins-api-docs/blob/master/docker-compose.yml#L8) lists different port than the one in the [README.md](https://github.com/designmynight/collins-api-docs/blob/master/README.md?plain=1#L27)

